### PR TITLE
Merge c++11+ compatibility header 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 project(Libalgebra VERSION 1.0.0)
 
 
-
+include(GNUInstallDirs)
 
 
 set(CMAKE_CXX_STANDARD 98)
@@ -11,7 +11,7 @@ set(CMAKE_CXX_STANDARD 98)
 find_package(Boost COMPONENTS thread)
 
 
-add_library(Libalgebra INTERFACE)
+add_library(Libalgebra INTERFACE ${CMAKE_CURRENT_LIST_DIR})
 
 target_include_directories(Libalgebra
         INTERFACE
@@ -22,7 +22,7 @@ add_library(Libalgebra::Libalgebra ALIAS Libalgebra)
 
 target_link_libraries(Libalgebra INTERFACE Boost::Boost)
 
-include(GNUInstallDirs)
+
 install(TARGETS Libalgebra
         EXPORT LibalgebraTargets
         INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ target_include_directories(Libalgebra
 
 add_library(Libalgebra::Libalgebra ALIAS Libalgebra)
 
-target_link_libraries(Libalgebra INTERFACE Boost)
+target_link_libraries(Libalgebra INTERFACE Boost::Boost)
 
 if(NOT_SUBPROJECT)
     install(TARGETS Libalgebra

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,11 +20,11 @@ set(CMAKE_CXX_STANDARD 98)
 
 find_package(Boost COMPONENTS thread)
 
-add_library(Libalgebra INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+add_library(Libalgebra INTERFACE)
 
 target_include_directories(Libalgebra
         INTERFACE
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
         )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 
-project(libalgebra VERSION 1.0.0)
+project(Libalgebra VERSION 1.0.0)
 
 
 
@@ -11,50 +11,51 @@ set(CMAKE_CXX_STANDARD 98)
 find_package(Boost COMPONENTS thread)
 
 
-add_library(Libalgebra INTERFACE
-        libalgebra/libalgebra.h
-        libalgebra/_tensor_basis.h
-        libalgebra/algebra.h
-        libalgebra/basis_traits.h
-        libalgebra/constlog2.h
-        libalgebra/constpower.h
-        libalgebra/implimentation_types.h
-        libalgebra/lie.h
-        libalgebra/lie_basis.h
-        libalgebra/monomial_basis.h
-        libalgebra/multi_polynomial.h
-        libalgebra/poly_basis.h
-        libalgebra/poly_lie.h
-        libalgebra/poly_lie_basis.h
-        libalgebra/polynomials.h
-        libalgebra/sparse_vector.h
-        libalgebra/tensor.h
-        libalgebra/tensor_basis.h
-        libalgebra/utils.h
+add_library(Libalgebra INTERFACE)
+
+target_include_directories(Libalgebra
+        INTERFACE
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/libalgebra>
         )
-target_link_libraries(Libalgebra INTERFACE Boost)
+
+add_library(Libalgebra::Libalgebra ALIAS Libalgebra)
+
+target_link_libraries(Libalgebra INTERFACE Boost::Boost)
 
 include(GNUInstallDirs)
 install(TARGETS Libalgebra
         EXPORT LibalgebraTargets
-        INCLUDES DESTINATION include
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         )
 
 include(CMakePackageConfigHelpers)
+set(LIBALGEBRA_CMAKE_CONFIG_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Libalgebra")
+
+message(STATUS "Writing cmake config file")
+configure_package_config_file(
+        LibalgebraConfig.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/LibalgebraConfig.cmake
+        INSTALL_DESTINATION ${LIBALGEBRA_CMAKE_CONFIG_DESTINATION}
+        PATH_VARS CMAKE_INSTALL_INCLUDEDIR
+)
+
+message(STATUS "Writing cmake config version file")
 write_basic_package_version_file(
         LibalgebraConfigVersion.cmake
         VERSION ${PACKAGE_VERSION}
         COMPATIBILITY SameMajorVersion
+        ARCH_INDEPENDENT
 )
+
+message(STATUS "Installing config files to ${LIBALGEBRA_CMAKE_CONFIG_DESTINATION}")
+install(FILES   ${CMAKE_CURRENT_BINARY_DIR}/LibalgebraConfig.cmake
+                ${CMAKE_CURRENT_BINARY_DIR}/LibalgebraConfigVersion.cmake
+        DESTINATION ${LIBALGEBRA_CMAKE_CONFIG_DESTINATION}
+        )
+
 
 install(EXPORT LibalgebraTargets
         FILE LibalgebraTargets.cmake
         NAMESPACE Libalgebra::
-        DESTINATION lib/cmake/Libalgebra
-        )
-
-configure_file(LibalgebraConfig.cmake.in LibalgebraConfig.cmake @ONLY)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/LibalgebraConfig.cmake"
-              "${CMAKE_CURRENT_BINARY_DIR}/LibalgebraConfigVersion.cmake"
         DESTINATION lib/cmake/Libalgebra
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ include(GNUInstallDirs)
 
 set(CMAKE_CXX_STANDARD 98)
 
-find_package(Boost COMPONENTS thread)
+find_package(Boost REQUIRED COMPONENTS thread)
 
 add_library(Libalgebra INTERFACE)
 
@@ -30,7 +30,7 @@ target_include_directories(Libalgebra
 
 add_library(Libalgebra::Libalgebra ALIAS Libalgebra)
 
-target_link_libraries(Libalgebra INTERFACE Boost::Boost)
+target_link_libraries(Libalgebra INTERFACE Boost::boost Boost::thread)
 
 if(NOT_SUBPROJECT)
     install(TARGETS Libalgebra

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(Libalgebra
 
 add_library(Libalgebra::Libalgebra ALIAS Libalgebra)
 
-target_link_libraries(Libalgebra INTERFACE Boost::Boost)
+target_link_libraries(Libalgebra INTERFACE Boost)
 
 
 install(TARGETS Libalgebra

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(libalgebra VERSION 1.0.0)
+
+
+
+
+
+set(CMAKE_CXX_STANDARD 98)
+
+find_package(Boost COMPONENTS thread)
+
+
+add_library(Libalgebra INTERFACE
+        libalgebra/libalgebra.h
+        libalgebra/_tensor_basis.h
+        libalgebra/algebra.h
+        libalgebra/basis_traits.h
+        libalgebra/constlog2.h
+        libalgebra/constpower.h
+        libalgebra/implimentation_types.h
+        libalgebra/lie.h
+        libalgebra/lie_basis.h
+        libalgebra/monomial_basis.h
+        libalgebra/multi_polynomial.h
+        libalgebra/poly_basis.h
+        libalgebra/poly_lie.h
+        libalgebra/poly_lie_basis.h
+        libalgebra/polynomials.h
+        libalgebra/sparse_vector.h
+        libalgebra/tensor.h
+        libalgebra/tensor_basis.h
+        libalgebra/utils.h
+        )
+target_link_libraries(Libalgebra INTERFACE Boost)
+
+include(GNUInstallDirs)
+install(TARGETS Libalgebra
+        EXPORT LibalgebraTargets
+        INCLUDES DESTINATION include
+        )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+        LibalgebraConfigVersion.cmake
+        VERSION ${PACKAGE_VERSION}
+        COMPATIBILITY SameMajorVersion
+)
+
+install(EXPORT LibalgebraTargets
+        FILE LibalgebraTargets.cmake
+        NAMESPACE Libalgebra::
+        DESTINATION lib/cmake/Libalgebra
+        )
+
+configure_file(LibalgebraConfig.cmake.in LibalgebraConfig.cmake @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/LibalgebraConfig.cmake"
+              "${CMAKE_CURRENT_BINARY_DIR}/LibalgebraConfigVersion.cmake"
+        DESTINATION lib/cmake/Libalgebra
+        )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,15 @@
 cmake_minimum_required(VERSION 3.0)
 
+# I took this from CATCH2's (V2.0) CMakeList.txt because
+# this seems to be close to our use case here.
+# https://github.com/catchorg/Catch2/blob/v2.x/CMakeLists.txt
+if(NOT DEFINED PROJECT_NAME)
+    set(NOT_SUBPROJECT ON)
+else()
+    set(NOT_SUBPROJECT OFF)
+endif()
+
+
 project(Libalgebra VERSION 1.0.0)
 
 
@@ -10,52 +20,53 @@ set(CMAKE_CXX_STANDARD 98)
 
 find_package(Boost COMPONENTS thread)
 
-
 add_library(Libalgebra INTERFACE ${CMAKE_CURRENT_LIST_DIR})
 
 target_include_directories(Libalgebra
         INTERFACE
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/libalgebra>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
         )
 
 add_library(Libalgebra::Libalgebra ALIAS Libalgebra)
 
 target_link_libraries(Libalgebra INTERFACE Boost)
 
+if(NOT_SUBPROJECT)
+    install(TARGETS Libalgebra
+            EXPORT LibalgebraTargets
+            INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+            )
 
-install(TARGETS Libalgebra
-        EXPORT LibalgebraTargets
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-        )
+    include(CMakePackageConfigHelpers)
+    set(LIBALGEBRA_CMAKE_CONFIG_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Libalgebra")
 
-include(CMakePackageConfigHelpers)
-set(LIBALGEBRA_CMAKE_CONFIG_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Libalgebra")
+    message(STATUS "Writing cmake config file")
+    configure_package_config_file(
+            LibalgebraConfig.cmake.in
+            ${CMAKE_CURRENT_BINARY_DIR}/LibalgebraConfig.cmake
+            INSTALL_DESTINATION ${LIBALGEBRA_CMAKE_CONFIG_DESTINATION}
+            PATH_VARS CMAKE_INSTALL_INCLUDEDIR
+    )
 
-message(STATUS "Writing cmake config file")
-configure_package_config_file(
-        LibalgebraConfig.cmake.in
-        ${CMAKE_CURRENT_BINARY_DIR}/LibalgebraConfig.cmake
-        INSTALL_DESTINATION ${LIBALGEBRA_CMAKE_CONFIG_DESTINATION}
-        PATH_VARS CMAKE_INSTALL_INCLUDEDIR
-)
+    message(STATUS "Writing cmake config version file")
+    write_basic_package_version_file(
+            LibalgebraConfigVersion.cmake
+            VERSION ${PACKAGE_VERSION}
+            COMPATIBILITY SameMajorVersion
+            ARCH_INDEPENDENT
+    )
 
-message(STATUS "Writing cmake config version file")
-write_basic_package_version_file(
-        LibalgebraConfigVersion.cmake
-        VERSION ${PACKAGE_VERSION}
-        COMPATIBILITY SameMajorVersion
-        ARCH_INDEPENDENT
-)
-
-message(STATUS "Installing config files to ${LIBALGEBRA_CMAKE_CONFIG_DESTINATION}")
-install(FILES   ${CMAKE_CURRENT_BINARY_DIR}/LibalgebraConfig.cmake
-                ${CMAKE_CURRENT_BINARY_DIR}/LibalgebraConfigVersion.cmake
-        DESTINATION ${LIBALGEBRA_CMAKE_CONFIG_DESTINATION}
-        )
+    message(STATUS "Installing config files to ${LIBALGEBRA_CMAKE_CONFIG_DESTINATION}")
+    install(FILES   ${CMAKE_CURRENT_BINARY_DIR}/LibalgebraConfig.cmake
+                    ${CMAKE_CURRENT_BINARY_DIR}/LibalgebraConfigVersion.cmake
+            DESTINATION ${LIBALGEBRA_CMAKE_CONFIG_DESTINATION}
+            )
 
 
-install(EXPORT LibalgebraTargets
-        FILE LibalgebraTargets.cmake
-        NAMESPACE Libalgebra::
-        DESTINATION lib/cmake/Libalgebra
-        )
+    install(EXPORT LibalgebraTargets
+            FILE LibalgebraTargets.cmake
+            NAMESPACE Libalgebra::
+            DESTINATION lib/cmake/Libalgebra
+            )
+endif()

--- a/LibalgebraConfig.cmake.in
+++ b/LibalgebraConfig.cmake.in
@@ -4,7 +4,7 @@ set(LIBALGEBRA_VERSION 1.0.0)
 
 @PACKAGE_INIT@
 
-find_dependency(Boost COMPONENTS thread REQUIRED)
+add_dependency(Boost COMPONENTS thread REQUIRED)
 
 set_and_check(LIBALGEBRA_INCLUDE_DIR "@CMAKE_INSTALL_INCLUDEDIR@")
 

--- a/LibalgebraConfig.cmake.in
+++ b/LibalgebraConfig.cmake.in
@@ -1,6 +1,12 @@
 include(CMakeFindDependencyMacro)
 
+set(LIBALGEBRA_VERSION 1.0.0)
+
+@PACKAGE_INIT@
+
 find_dependency(Boost COMPONENTS thread REQUIRED)
 
+set_and_check(LIBALGEBRA_INCLUDE_DIR "@CMAKE_INSTALL_INCLUDEDIR@")
 
-include("${CMAKE_CURRENT_BINARY_DIR}/LibalgebraTargets.cmake")
+
+check_required_components(Libalgebra)

--- a/LibalgebraConfig.cmake.in
+++ b/LibalgebraConfig.cmake.in
@@ -1,0 +1,6 @@
+include(CMakeFindDependencyMacro)
+
+find_dependency(Boost COMPONENTS thread REQUIRED)
+
+
+include("${CMAKE_CURRENT_BINARY_DIR}/LibalgebraTargets.cmake")

--- a/LibalgebraConfig.cmake.in
+++ b/LibalgebraConfig.cmake.in
@@ -4,9 +4,11 @@ set(LIBALGEBRA_VERSION 1.0.0)
 
 @PACKAGE_INIT@
 
-add_dependency(Boost COMPONENTS thread REQUIRED)
+find_dependency(Boost COMPONENTS thread REQUIRED)
 
 set_and_check(LIBALGEBRA_INCLUDE_DIR "@CMAKE_INSTALL_INCLUDEDIR@")
 
+
+include(${CMAKE_CURRENT_LIST_DIR}/LibalgebraTargets.cmake)
 
 check_required_components(Libalgebra)

--- a/libalgebra/coefficients/coefficients.h
+++ b/libalgebra/coefficients/coefficients.h
@@ -9,9 +9,9 @@ namespace alg {
 namespace coefficients {
 
 #define LIBALGEBRA_FIELD_GENERATE_BINARY(NAME, OP, RET_T, LHS_T, RHS_T)        \
-  static RET_T NAME(LHS_T const &lhs, RHS_T const &rhs) { return lhs OP rhs; } \
+  static LA_CONSTEXPR RET_T NAME(LHS_T const &lhs, RHS_T const &rhs) { return lhs OP rhs; } \
                                                                                \
-  static LHS_T &NAME##_inplace(LHS_T &lhs, RHS_T const &rhs) {                 \
+  static LA_CONSTEXPR LHS_T &NAME##_inplace(LHS_T &lhs, RHS_T const &rhs) {                 \
     return (lhs OP## = rhs);                                                   \
   }
 
@@ -27,7 +27,7 @@ template <typename Scalar, typename Rational = Scalar> struct coefficient_field
     static const SCA zero;
     static const SCA mone;
 
-    static SCA uminus(SCA arg) { return -arg; }
+    static LA_CONSTEXPR SCA uminus(SCA arg) { return -arg; }
 
     LIBALGEBRA_FIELD_GENERATE_BINARY(add, +, SCA, SCA, SCA);
 

--- a/libalgebra/compat.h
+++ b/libalgebra/compat.h
@@ -1,0 +1,22 @@
+//
+// Created by sam on 13/07/2021.
+//
+
+#ifndef LIBALGEBRA_COMPAT_H
+#define LIBALGEBRA_COMPAT_H
+
+
+#if __cplusplus >= 201103UL
+#define LA_CONSTEXPR constexpr
+#define LA_EXPLICIT explicit
+#else
+#define LA_CONSTEXPR
+#define LA_EXPLICIT
+#endif
+
+
+
+
+
+
+#endif //LIBALGEBRA_COMPAT_H

--- a/libalgebra/compat.h
+++ b/libalgebra/compat.h
@@ -8,10 +8,8 @@
 
 #if __cplusplus >= 201103UL
 #define LA_CONSTEXPR constexpr
-#define LA_EXPLICIT explicit
 #else
 #define LA_CONSTEXPR
-#define LA_EXPLICIT
 #endif
 
 

--- a/libalgebra/libalgebra.h
+++ b/libalgebra/libalgebra.h
@@ -54,6 +54,7 @@ typedef unsigned __int64 uint64_t;
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/shared_mutex.hpp>
 
+#include "compat.h"
 #include "implimentation_types.h"
 #include <boost/thread/locks.hpp>
 

--- a/libalgebra/multiplication_helpers.h
+++ b/libalgebra/multiplication_helpers.h
@@ -5,13 +5,6 @@
 #ifndef LIBALGEBRA_MULTIPLICATION_HELPERS_H
 #define LIBALGEBRA_MULTIPLICATION_HELPERS_H
 
-#ifndef LA_EXPLICIT
-#define LA_EXPLICIT explicit
-#endif
-#ifndef LA_CONSTEXPR
-#define LA_CONSTEXPR constexpr
-#endif
-
 namespace alg {
 namespace mult {
 
@@ -35,7 +28,7 @@ template <typename Coeff> struct scalar_post_mult
 {
     typedef typename Coeff::SCA scalar_t;
 
-    LA_EXPLICIT LA_CONSTEXPR scalar_post_mult(const scalar_t factor = Coeff::one) : m_factor(factor) {}
+    LA_CONSTEXPR explicit scalar_post_mult(const scalar_t factor = Coeff::one) : m_factor(factor) {}
 
     LA_CONSTEXPR scalar_t operator()(scalar_t val) const
     {
@@ -51,7 +44,7 @@ template <typename Coeff> struct rational_post_div
     typedef typename Coeff::SCA scalar_t;
     typedef typename Coeff::RAT rational_t;
 
-    LA_EXPLICIT LA_CONSTEXPR rational_post_div(const rational_t factor) : m_factor(Coeff::div(Coeff::one, factor)) {}
+    LA_CONSTEXPR explicit rational_post_div(const rational_t factor) : m_factor(Coeff::div(Coeff::one, factor)) {}
 
     LA_CONSTEXPR scalar_t operator()(scalar_t val) const
     {

--- a/libalgebra/vectors/base_vector.h
+++ b/libalgebra/vectors/base_vector.h
@@ -10,12 +10,13 @@
 namespace alg {
 namespace vectors {
 
-template <typename Basis, typename Field> class base_vector
+template <typename Basis, typename Coeff>
+class base_vector
 {
 public:
     typedef Basis BASIS;
-    typedef typename Field::S SCALAR;
-    typedef typename Field::Q RATIONAL;
+    typedef typename Coeff::S SCALAR;
+    typedef typename Coeff::Q RATIONAL;
 
     typedef typename alg::basis::basis_traits<Basis> BASIS_TRAITS;
 
@@ -30,19 +31,19 @@ public:
 // Initialisation of static members of base_vector
 
 /// Static initialisation of the sparse_vector basis.
-template <typename Basis, typename Field> Basis base_vector<Basis, Field>::basis;
+template <typename Basis, typename Coeff> Basis base_vector<Basis, Coeff>::basis;
 
 /// Static initialisation of the scalar constant +1.
-template <typename Basis, typename Field> const typename Field::S base_vector<Basis, Field>::one(+1);
+template <typename Basis, typename Coeff> const typename Coeff::S base_vector<Basis, Coeff>::one(Coeff::one);
 
 /// Static initialisation of the scalar constant 0.
-template <typename Basis, typename Field> const typename Field::S base_vector<Basis, Field>::zero(0);
+template <typename Basis, typename Coeff> const typename Coeff::S base_vector<Basis, Coeff>::zero(Coeff::zero);
 
 /// Static initialisation of the scalar constant -1.
-template <typename Basis, typename Field> const typename Field::S base_vector<Basis, Field>::mone(-1);
+template <typename Basis, typename Coeff> const typename Coeff::S base_vector<Basis, Coeff>::mone(Coeff::mone);
 
-template <typename Basis, typename Field> const typename alg::basis::basis_traits<Basis>::degree_tag
-        base_vector<Basis, Field>::degree_tag;
+template <typename Basis, typename Coeff> const typename alg::basis::basis_traits<Basis>::degree_tag
+        base_vector<Basis, Coeff>::degree_tag;
 
 } // namespace vectors
 } // namespace alg


### PR DESCRIPTION
This adds a macro `LA_CONSTEXPR` that can be used to conditionally add constexpr to a function when compiled with C++11 enabled.