### PR TITLE
Added initializer list ctor for _tensor_basis

### DIFF
--- a/libalgebra/_tensor_basis.h
+++ b/libalgebra/_tensor_basis.h
@@ -131,6 +131,18 @@ public:
         }
     }
 
+#if __cplusplus >= 201103UL
+
+    _tensor_basis(std::initializer_list<LET> letters) : _word{1.0}
+    {
+        for (auto let : letters) {
+            assert(1<= let && let <= No_Letters);
+            push_back(let);
+        }
+    }
+
+#endif
+
     /// Destructor
     ~_tensor_basis(void) {}
 


### PR DESCRIPTION
Added a new constructor for tensor words (when compiling with C++11 support) . With this, we can create tensor keys much more easily as follows:
```c++
using key_type = alg::_tensor_basis<2, 2>; // for example

key_type k { 1, 2, 1, 2};
```
This should create the tensor key (1,2,1,2).