### PR TITLE
Fixed a misordering of the include for hall set and boost/locks

### DIFF
--- a/libalgebra/hall_set.h
+++ b/libalgebra/hall_set.h
@@ -579,7 +579,7 @@ public:
             static boost::recursive_mutex table_lock;
             static table_t table;
 
-            typename boost::lock_guard<typename boost::recursive_mutex> access(table_lock);
+            boost::lock_guard<boost::recursive_mutex> access(table_lock);
 
             typename table_t::iterator it = table.find(k);
             if (it != table.end()) {

--- a/libalgebra/hall_set.h
+++ b/libalgebra/hall_set.h
@@ -560,7 +560,7 @@ public:
             static table_t table;
 
             if (tag.predicate(k)) {
-                boost::lock_guard<boost::recursive_mutex> access(table_lock);
+                typename boost::lock_guard<typename boost::recursive_mutex> access(table_lock);
 
                 typename table_t::iterator it = table.find(k);
                 if (it != table.end()) {
@@ -579,7 +579,7 @@ public:
             static boost::recursive_mutex table_lock;
             static table_t table;
 
-            boost::lock_guard<boost::recursive_mutex> access(table_lock);
+            typename boost::lock_guard<typename boost::recursive_mutex> access(table_lock);
 
             typename table_t::iterator it = table.find(k);
             if (it != table.end()) {

--- a/libalgebra/hall_set.h
+++ b/libalgebra/hall_set.h
@@ -560,7 +560,7 @@ public:
             static table_t table;
 
             if (tag.predicate(k)) {
-                typename boost::lock_guard<typename boost::recursive_mutex> access(table_lock);
+                boost::lock_guard<boost::recursive_mutex> access(table_lock);
 
                 typename table_t::iterator it = table.find(k);
                 if (it != table.end()) {

--- a/libalgebra/libalgebra.h
+++ b/libalgebra/libalgebra.h
@@ -51,12 +51,9 @@ typedef unsigned __int64 uint64_t;
 #include <utility>
 #include <vector>
 
+#include <boost/thread/locks.hpp>
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/thread/locks.hpp>
-
-#include "hall_set.h"
-#include "implementation_types.h"
 
 //#define ORDEREDMAP
 #define UNORDEREDMAP
@@ -106,6 +103,8 @@ typedef unsigned __int64 uint64_t;
    operators are + - * / and explicit ctor from SCA type and int type.
 */
 
+#include "hall_set.h"
+#include "implementation_types.h"
 #include "libalgebra/utils/integer_maths.h"
 #include "libalgebra/vectors/vectors.h"
 #include "multiplication_helpers.h"

--- a/libalgebra/libalgebra.h
+++ b/libalgebra/libalgebra.h
@@ -53,10 +53,10 @@ typedef unsigned __int64 uint64_t;
 
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/shared_mutex.hpp>
+#include <boost/thread/locks.hpp>
 
 #include "hall_set.h"
 #include "implementation_types.h"
-#include <boost/thread/locks.hpp>
 
 //#define ORDEREDMAP
 #define UNORDEREDMAP


### PR DESCRIPTION
On the current version of boost libalgebra develop branch does not compile. Adding a few typenames to hall_set.h revealed that the lock_guard was not defined. Reordering the headers in Libalgebra fixes this for my code. I left the typenames in.