### PR TITLE
Dense vector iterator fixes

### DIFF
--- a/libalgebra/dense_vector.h
+++ b/libalgebra/dense_vector.h
@@ -323,7 +323,7 @@ public:
     private:
         bool compare_iterators(const iterator_item& other) const
         {
-            return (m_iterator == other.m_iterator);
+            return (m_iterator >= other.m_iterator);
         }
 
         void advance()
@@ -376,7 +376,7 @@ public:
     private:
         bool compare_iterators(const const_iterator_item& other) const
         {
-            return (m_iterator == other.m_iterator);
+            return (m_iterator >= other.m_iterator);
         }
 
         void advance()

--- a/libalgebra/dense_vector.h
+++ b/libalgebra/dense_vector.h
@@ -328,7 +328,10 @@ public:
 
         void advance()
         {
-            ++m_iterator;
+            const auto end = m_vector->m_data.end();
+            do {
+                ++m_iterator;
+            } while (m_iterator != end && *m_iterator == Coeffs::zero);
         }
 
     public:
@@ -381,7 +384,10 @@ public:
 
         void advance()
         {
-            ++m_iterator;
+            const auto end = m_vector->m_data.end();
+            do {
+                ++m_iterator;
+            } while (m_iterator != end && *m_iterator == Coeffs::zero);
         }
 
     public:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,7 +31,7 @@ message(STATUS ">>> OpenMP_CXX_FLAGS = ${OpenMP_CXX_FLAGS}")
 message(STATUS ">>> Boost libraries: ${Boost_LIBRARIES}")
 
 add_subdirectory(common)
-if (LA_TESTIN_INCLUDE_INTEGRATION)
+if (LA_TESTING_INCLUDE_INTEGRATION)
     add_subdirectory(integration_tests)
 endif ()
 


### PR DESCRIPTION
Fix the dense vector iterators to skip zero elements so that these iterators do not leak implementation details about the vector.